### PR TITLE
Fix/vaultaddr response parsing

### DIFF
--- a/api.go
+++ b/api.go
@@ -46,14 +46,18 @@ func (r *APIResponse[T]) UnmarshalJSON(data []byte) error {
 
 	// When status is "ok", "response" contains "type" and "data"
 	r.Type = string(parsed.GetStringBytes("response", "type"))
-	responseData := parsed.GetStringBytes("response", "data")
+
+	// GetStringBytes() only works on string, we should do a Get instead
+	responseData := parsed.Get("response", "data")
 
 	if responseData == nil {
 		return fmt.Errorf("missing response.data field in successful response")
 	}
 
+	b := responseData.MarshalTo(nil)
+
 	// Use fastjson's built-in unmarshaling if possible, fallback to json.Unmarshal
-	if err := json.Unmarshal(responseData, &r.Data); err != nil {
+	if err := json.Unmarshal(b, &r.Data); err != nil {
 		return fmt.Errorf("failed to unmarshal response data: %w", err)
 	}
 

--- a/exchange.go
+++ b/exchange.go
@@ -70,17 +70,19 @@ func (e *Exchange) postAction(
 		"signature": signature,
 	}
 
-	// Handle vault address based on action type
-	if actionMap, ok := action.(map[string]any); ok {
-		if actionMap["type"] != "usdClassTransfer" {
-			payload["vaultAddress"] = e.vault
+	if e.vault != "" {
+		// Handle vault address based on action type
+		if actionMap, ok := action.(map[string]any); ok {
+			if actionMap["type"] != "usdClassTransfer" {
+				payload["vaultAddress"] = e.vault
+			} else {
+				payload["vaultAddress"] = nil
+			}
 		} else {
-			payload["vaultAddress"] = nil
+			// For struct types, we need to use reflection or type assertion
+			// For now, assume it's not usdClassTransfer
+			payload["vaultAddress"] = e.vault
 		}
-	} else {
-		// For struct types, we need to use reflection or type assertion
-		// For now, assume it's not usdClassTransfer
-		payload["vaultAddress"] = e.vault
 	}
 
 	// Add expiration time if set

--- a/exchange_orders.go
+++ b/exchange_orders.go
@@ -1,6 +1,7 @@
 package hyperliquid
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -39,7 +40,12 @@ type OrderStatusFilled struct {
 type OrderStatus struct {
 	Resting *OrderStatusResting `json:"resting,omitempty"`
 	Filled  *OrderStatusFilled  `json:"filled,omitempty"`
-	Error   *error              `json:"error,omitempty"`
+	Error   *string             `json:"error,omitempty"`
+}
+
+func (s *OrderStatus) String() string {
+	data, _ := json.Marshal(s)
+	return string(data)
 }
 
 type OrderResponse struct {


### PR DESCRIPTION
# Pull Request

## Description
 Fixes multiple issues in API response handling and request building:

* Correctly parse `response.data` as JSON when it’s an object or array.
* Omit `vaultAddress` from payloads when empty to avoid API 422 errors.
* Change `OrderStatus.Error` from `*error` to `*string` for proper unmarshalling, and add a `String()` helper for easier debugging.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `make ci-full` and all checks pass

The existing tests pass/fail the same as before, they are broken. Not going to fix them.

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings