### PR TITLE
APIResponse Order field mapping

### DIFF
--- a/apiresponse_test.go
+++ b/apiresponse_test.go
@@ -1,0 +1,45 @@
+package hyperliquid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIResponse_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		want     *APIResponse[OrderResponse]
+	}{
+		{
+			name:     "CreateOrderRequest Response",
+			jsonData: `{"status":"ok","response":{"type":"order","data":{"statuses":[{"resting":{"oid":12345678901,"cloid":"0x00000000000000000000000000000000"}}]}}}`,
+			want: &APIResponse[OrderResponse]{
+				Status: "ok",
+				Ok:     true,
+				Type:   "order",
+				Data: OrderResponse{
+					Statuses: []OrderStatus{
+						{
+							Resting: &OrderStatusResting{
+								Oid:      12345678901,
+								ClientID: "0x00000000000000000000000000000000",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := &APIResponse[OrderResponse]{}
+			err := res.UnmarshalJSON([]byte(tt.jsonData))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, res)
+		})
+	}
+}

--- a/exchange_orders.go
+++ b/exchange_orders.go
@@ -27,7 +27,7 @@ type createOrderRequest struct {
 
 type OrderStatusResting struct {
 	Oid      int64  `json:"oid"`
-	ClientID string `json:"cid"`
+	ClientID string `json:"cloid"`
 	Status   string `json:"status"`
 }
 


### PR DESCRIPTION
I forgot in my recent PR to write a unit test which with further testing showed there was another bug, I might find more over time as my implementation using this SDK is nearing completion :)

test(api): add unit test for APIResponse.UnmarshalJSON and fix cloid field mapping

- Add apiresponse_test.go to verify correct parsing of CreateOrderRequest responses.
- Fix JSON tag for OrderStatusResting.ClientID from "cid" to "cloid" to match API schema.

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement