### PR TITLE
fix(signing): enable compact ints in msgpack encoder

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -32,6 +32,7 @@ func actionHash(action any, vaultAddress string, nonce int64, expiresAfter *int6
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)
 	enc.SetSortMapKeys(true)
+	enc.UseCompactInts(true)
 
 	err := enc.Encode(action)
 	if err != nil {


### PR DESCRIPTION
Small PR but big impact, this bubbled up as I was writing unit tests for Cancel as proposed in #18.

I for the life of me could not get a single Cancel out there, eventually I decided to compare the hex dumps of what Python packs and what Go packs and noticed a difference in the integer sizes. There was a suspicion but wasn't sure.

I decided to split it off as I want to do a proper code revert tomorrow (I tried a _lot_) to see what is really required and not. But this is for now a big one we need to match!

Hyperliquid’s backend (and the official Python SDK) serialise all small integers using msgpack’s compact-int formats (uint8/uint16/uint32/uint64). Our Go signer always emitted the int64 tag (0xd3), which changed the bytes that are hashed and caused cancel / modify signatures to recover an invalid wallet address (“User or API Wallet … does not exist.”).