### PR TITLE
fix: add missing values from UserFees to struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -230,6 +230,8 @@ type UserFees struct {
 	FeeSchedule            FeeSchedule  `json:"feeSchedule"`
 	UserAddRate            string       `json:"userAddRate"`
 	UserCrossRate          string       `json:"userCrossRate"`
+	UserSpotCrossRate      string       `json:"userSpotCrossRate"`
+	UserSpotAddRate        string       `json:"userSpotAddRate"`
 }
 
 type UserVolume struct {

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -635,6 +635,10 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid6(in *jlexer.Lexer, out
 			out.UserAddRate = string(in.String())
 		case "userCrossRate":
 			out.UserCrossRate = string(in.String())
+		case "userSpotCrossRate":
+			out.UserSpotCrossRate = string(in.String())
+		case "userSpotAddRate":
+			out.UserSpotAddRate = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -684,6 +688,16 @@ func easyjson6601e8cdEncodeGithubComSoniricoGoHyperliquid6(out *jwriter.Writer, 
 		const prefix string = ",\"userCrossRate\":"
 		out.RawString(prefix)
 		out.String(string(in.UserCrossRate))
+	}
+	{
+		const prefix string = ",\"userSpotCrossRate\":"
+		out.RawString(prefix)
+		out.String(string(in.UserSpotCrossRate))
+	}
+	{
+		const prefix string = ",\"userSpotAddRate\":"
+		out.RawString(prefix)
+		out.String(string(in.UserSpotAddRate))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Pull Request

## Description
Added 2 values to the UserFees info method that Hyperliquid returns, but this sdk did not parse yet.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have run `make ci-full` and all checks pass (this does not exist?)

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [x] Generated files are up to date with struct changes
