### PR TITLE
fix: remove unnecessary println from client post method

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,7 +39,6 @@ func NewClient(baseURL string) *Client {
 
 func (c *Client) post(path string, payload any) ([]byte, error) {
 	jsonData, err := json.Marshal(payload)
-	fmt.Println(string(jsonData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal payload: %w", err)
 	}


### PR DESCRIPTION
# Pull Request

## Description
There is a (what feels like) random console print in the post method of the client. It was logging also in go apps that consume this library, which is not ideal.