### PR TITLE
chore(ws): prevent unnecessary ping dispatch error log

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -202,6 +202,10 @@ func (w *WebsocketClient) readPump(ctx context.Context) {
 				continue
 			}
 
+			if wsMsg.Channel == ChannelPong {
+				continue
+			}
+
 			if err := w.dispatch(wsMsg); err != nil {
 				log.Printf("failed to dispatch websocket message: %v", err)
 			}

--- a/ws_types.go
+++ b/ws_types.go
@@ -14,6 +14,7 @@ const (
 	ChannelNotification string = "notification"
 	ChannelOrderUpdates string = "orderUpdates"
 	ChannelSubResponse  string = "subscriptionResponse"
+	ChannelPong         string = "pong"
 )
 
 type wsMessage struct {


### PR DESCRIPTION
Right now every 50s it keeps logging a dispatch error as the "pong" channel is unhandled. This will prevent that.

We should probably consider also verifying that we actually receive pongs and if not, try reconnecting? I was working on implementing this, but realized the current reconnect method is not yet suited for this as it only works when the conn is actually nil due to an error for example.
