### PR TITLE
fix: ensure significant figures rounding is implemented for slippage price calculation

### DIFF
--- a/exchange_others.go
+++ b/exchange_others.go
@@ -90,6 +90,12 @@ func (e *Exchange) SlippagePrice(
 		price *= (1 - slippage)
 	}
 
+	// First we need to round the price to Hyperliquid's max 5 significant figures (see: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size)
+	price, err := roundToSignificantFigures(price, 5)
+	if err != nil {
+		return 0, err
+	}
+
 	// Round to appropriate decimals
 	decimals := 6
 	if isSpot {

--- a/utils.go
+++ b/utils.go
@@ -61,3 +61,44 @@ func floatToWire(x float64) (string, error) {
 
 	return result, nil
 }
+
+func roundToSignificantFigures(price float64, sigFigs int) (float64, error) {
+	if price == 0 {
+		return 0, nil
+	}
+
+	// Work with the absolute value of the price to simplify calculations. We will restore the sign later.
+	absPrice := math.Abs(price)
+
+	// Determine the integer part of the absolute price (e.g., for 123.45, integerPart is 123).
+	integerPart := math.Floor(absPrice)
+
+	// Calculate the number of digits in the integer part.
+	// This helps in deciding if we're rounding to an integer or including fractional parts.
+	numIntegerDigits := 0
+	if integerPart > 0 {
+		// Count the number of digits in the integer part.
+		temp := int(integerPart)
+		for temp > 0 {
+			temp = temp / 10
+			numIntegerDigits++
+		}
+	} else {
+		// Since we know the price is not 0 and thus is a fraction, 0 is a significant figure.
+		numIntegerDigits = 1
+	}
+
+	if numIntegerDigits >= sigFigs {
+		// Returning the integer part, keeping the original sign.
+		// We do need to preserve the whole integer part, even though it may result in more significant figures than requested.
+		return math.Copysign(integerPart, price), nil
+	}
+
+	sigFigsLeft := sigFigs - numIntegerDigits
+
+	// Round the float64 to the number of significant figures left.
+	rounded := roundToDecimals(absPrice, sigFigsLeft)
+
+	// Return the rounded number, applying the original sign.
+	return math.Copysign(rounded, price), nil
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,55 @@
+package hyperliquid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundToSignificantFigures(t *testing.T) {
+	tests := []struct {
+		name     string
+		price    float64
+		sigFigs  int
+		expected float64
+	}{
+		{
+			name:     "keeps all digits",
+			price:    123.456789,
+			sigFigs:  9,
+			expected: 123.456789,
+		},
+		{
+			name:     "keeps 2 of the 3 decimal places",
+			price:    123.453,
+			sigFigs:  5,
+			expected: 123.45,
+		},
+		{
+			name:     "fraction below 1 should consider 0 as a significant figure",
+			price:    0.12,
+			sigFigs:  2,
+			expected: 0.1,
+		},
+		{
+			name:     "if integer part has more significant figures, return whole integer part",
+			price:    110454,
+			sigFigs:  5,
+			expected: 110454,
+		},
+		{
+			name:     "even if sigFigs is 0, return the whole integer part",
+			price:    24,
+			sigFigs:  0,
+			expected: 24,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rounded, err := roundToSignificantFigures(test.price, test.sigFigs)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, rounded)
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description
Currently, the price rounding is not fully done. Hyperliquid also requires us to round to a maximum of 5 significant figures, as seen in [the docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size). This PR ensures the significant figs rounding is done before the decimal rounding, which ensures we do not exceed the max amount of significant figs in the end.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
