### PR TITLE
feat: add MaxLeverage and MarginTableId to AssetInfo (metaAndAssetCtxs)

### DIFF
--- a/info_test.go
+++ b/info_test.go
@@ -34,10 +34,14 @@ func TestMetaAndAssetCtxs(t *testing.T) {
 		if asset.Name == "BTC" {
 			btcFound = true
 			require.Equal(t, 5, asset.SzDecimals)
+			require.Equal(t, 40, asset.MaxLeverage)
+			require.Equal(t, 56, asset.MarginTableId)
 		}
 		if asset.Name == "ETH" {
 			ethFound = true
 			require.Equal(t, 4, asset.SzDecimals)
+			require.Equal(t, 25, asset.MaxLeverage)
+			require.Equal(t, 55, asset.MarginTableId)
 		}
 	}
 	require.True(t, btcFound, "BTC asset should be present in universe")

--- a/types.go
+++ b/types.go
@@ -39,8 +39,10 @@ const (
 )
 
 type AssetInfo struct {
-	Name       string `json:"name"`
-	SzDecimals int    `json:"szDecimals"`
+	Name          string `json:"name"`
+	SzDecimals    int    `json:"szDecimals"`
+	MaxLeverage   int    `json:"maxLeverage"`
+	MarginTableId int    `json:"marginTableId"`
 }
 
 type MarginTier struct {

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4676,7 +4676,7 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid42(in *jlexer.Lexer, ou
 				in.Delim('[')
 				if out.Universe == nil {
 					if !in.IsDelim(']') {
-						out.Universe = make([]AssetInfo, 0, 2)
+						out.Universe = make([]AssetInfo, 0, 1)
 					} else {
 						out.Universe = []AssetInfo{}
 					}
@@ -4832,7 +4832,7 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid43(in *jlexer.Lexer, ou
 				in.Delim('[')
 				if out.Universe == nil {
 					if !in.IsDelim(']') {
-						out.Universe = make([]AssetInfo, 0, 2)
+						out.Universe = make([]AssetInfo, 0, 1)
 					} else {
 						out.Universe = []AssetInfo{}
 					}
@@ -6872,6 +6872,18 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid64(in *jlexer.Lexer, ou
 			} else {
 				out.SzDecimals = int(in.Int())
 			}
+		case "maxLeverage":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.MaxLeverage = int(in.Int())
+			}
+		case "marginTableId":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.MarginTableId = int(in.Int())
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -6895,6 +6907,16 @@ func easyjson6601e8cdEncodeGithubComSoniricoGoHyperliquid64(out *jwriter.Writer,
 		const prefix string = ",\"szDecimals\":"
 		out.RawString(prefix)
 		out.Int(int(in.SzDecimals))
+	}
+	{
+		const prefix string = ",\"maxLeverage\":"
+		out.RawString(prefix)
+		out.Int(int(in.MaxLeverage))
+	}
+	{
+		const prefix string = ",\"marginTableId\":"
+		out.RawString(prefix)
+		out.Int(int(in.MarginTableId))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Parse MaxLeverage and MarginTableId fields for AssetInfo

## Description
Adds missing fields for metaAndAssetCtxs method result, they are essential in order to choose Leverage for a particular asset when placing orders. [See the Original Documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#retrieve-perpetuals-asset-contexts-includes-mark-price-current-funding-open-interest-etc), it does miss MarginTableId field, though all the universe contain it as of now, maybe it's better to make it a pointer for safety reasons til HL guys update the docs

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [x] Generated files are up to date with struct changes