### PR TITLE
fix: userFills subscription channel name

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -69,7 +69,7 @@ func NewWebsocketClient(baseURL string, opts ...WsOpt) *WebsocketClient {
 			ChannelOrderUpdates: NewMsgDispatcher[WsOrders](ChannelOrderUpdates),
 			ChannelWebData2:     NewMsgDispatcher[WebData2](ChannelWebData2),
 			ChannelBbo:          NewMsgDispatcher[Bbo](ChannelBbo),
-			ChannelOrderFills:   NewMsgDispatcher[WsOrderFills](ChannelOrderFills),
+			ChannelUserFills:    NewMsgDispatcher[WsOrderFills](ChannelUserFills),
 			ChannelSubResponse:  NewNoopDispatcher(),
 		},
 	}

--- a/ws_sub_orderfills.go
+++ b/ws_sub_orderfills.go
@@ -11,7 +11,7 @@ func (w *WebsocketClient) OrderFills(
 	callback func(WsOrderFills, error),
 ) (*Subscription, error) {
 	payload := remoteOrderFillsSubscriptionPayload{
-		Type: ChannelOrderFills,
+		Type: ChannelUserFills,
 		User: params.User,
 	}
 

--- a/ws_types.go
+++ b/ws_types.go
@@ -14,7 +14,7 @@ const (
 	ChannelAllMids      string = "allMids"
 	ChannelNotification string = "notification"
 	ChannelOrderUpdates string = "orderUpdates"
-	ChannelOrderFills   string = "orderFills"
+	ChannelOrderFills   string = "userFills"
 	ChannelWebData2     string = "webData2"
 	ChannelBbo          string = "bbo"
 	ChannelSubResponse  string = "subscriptionResponse"

--- a/ws_types.go
+++ b/ws_types.go
@@ -14,7 +14,7 @@ const (
 	ChannelAllMids      string = "allMids"
 	ChannelNotification string = "notification"
 	ChannelOrderUpdates string = "orderUpdates"
-	ChannelOrderFills   string = "userFills"
+	ChannelUserFills    string = "userFills"
 	ChannelWebData2     string = "webData2"
 	ChannelBbo          string = "bbo"
 	ChannelSubResponse  string = "subscriptionResponse"

--- a/ws_types_remote.go
+++ b/ws_types_remote.go
@@ -96,7 +96,7 @@ func (p remoteOrderFillsSubscriptionPayload) Channel() string {
 }
 
 func (p remoteOrderFillsSubscriptionPayload) Key() string {
-	return keyOrderFills(p.User)
+	return keyUserFills(p.User)
 }
 
 type remoteWebData2SubscriptionPayload struct {

--- a/ws_types_subscriptable.go
+++ b/ws_types_subscriptable.go
@@ -55,5 +55,5 @@ func (w WebData2) Key() string {
 func (w Bbo) Key() string { return keyBbo(w.Coin) }
 
 func (w WsOrderFills) Key() string {
-	return keyOrderFills(w.User)
+	return keyUserFills(w.User)
 }

--- a/ws_utils.go
+++ b/ws_utils.go
@@ -48,7 +48,7 @@ func keyOrderUpdates(_ string) string {
 func keyOrderFills(user string) string {
 	// Order fills are user-specific but don't contain user info in the message itself.
 	// The dispatching is handled by the subscription system based on the subscription key.
-	return key(ChannelOrderFills, user)
+	return key(ChannelUserFills, user)
 }
 
 func keyWebData2(_ string) string {

--- a/ws_utils.go
+++ b/ws_utils.go
@@ -45,9 +45,7 @@ func keyOrderUpdates(_ string) string {
 	return key(ChannelOrderUpdates)
 }
 
-func keyOrderFills(user string) string {
-	// Order fills are user-specific but don't contain user info in the message itself.
-	// The dispatching is handled by the subscription system based on the subscription key.
+func keyUserFills(user string) string {
 	return key(ChannelUserFills, user)
 }
 


### PR DESCRIPTION
# Pull Request

## Description
In my previous PR I made an error. The correct channel name for subscribing to order fills is called `userFills`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [x] Generated files are up to date with struct changes
