### PR TITLE
fix(utils): fix significant figures rounding for fractions

### DIFF
--- a/exchange_others.go
+++ b/exchange_others.go
@@ -94,10 +94,7 @@ func (e *Exchange) SlippagePrice(
 	}
 
 	// First we need to round the price to Hyperliquid's max 5 significant figures (see: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size)
-	price, err := roundToSignificantFigures(price, 5)
-	if err != nil {
-		return 0, err
-	}
+	price = roundToSignificantFigures(price, 5)
 
 	// Round to appropriate decimals
 	decimals := 6

--- a/utils_test.go
+++ b/utils_test.go
@@ -26,12 +26,6 @@ func TestRoundToSignificantFigures(t *testing.T) {
 			expected: 123.45,
 		},
 		{
-			name:     "fraction below 1 should consider 0 as a significant figure",
-			price:    0.12,
-			sigFigs:  2,
-			expected: 0.1,
-		},
-		{
 			name:     "if integer part has more significant figures, return whole integer part",
 			price:    110454,
 			sigFigs:  5,
@@ -43,12 +37,17 @@ func TestRoundToSignificantFigures(t *testing.T) {
 			sigFigs:  0,
 			expected: 24,
 		},
+		{
+			name:     "test rounding a fraction",
+			price:    0.00252312,
+			sigFigs:  5,
+			expected: 0.0025231,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rounded, err := roundToSignificantFigures(test.price, test.sigFigs)
-			assert.NoError(t, err)
+			rounded := roundToSignificantFigures(test.price, test.sigFigs)
 			assert.Equal(t, test.expected, rounded)
 		})
 	}


### PR DESCRIPTION
# Pull Request

## Description
My original understanding of significant figures was wrong. The rounding currently did not work well for numbers below 1. This change will fix that. This could be implemented more efficiently potentially, but the way I did it now makes sense to me at least.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass
