### PR TITLE
fix(orders): wiring for bulk modify orders bug

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -147,7 +147,7 @@ type OrderAction struct {
 
 // ModifyAction represents a single order modification
 type ModifyAction struct {
-	Type  string    `json:"type"  msgpack:"type"`
+	Type  string    `json:"type,omitempty"  msgpack:"type,omitempty"`
 	Oid   any       `json:"oid"   msgpack:"oid"`
 	Order OrderWire `json:"order" msgpack:"order"`
 }

--- a/actions_easyjson.go
+++ b/actions_easyjson.go
@@ -2362,14 +2362,20 @@ func easyjsonB97b45a3EncodeGithubComSoniricoGoHyperliquid22(out *jwriter.Writer,
 	out.RawByte('{')
 	first := true
 	_ = first
-	{
+	if in.Type != "" {
 		const prefix string = ",\"type\":"
+		first = false
 		out.RawString(prefix[1:])
 		out.String(string(in.Type))
 	}
 	{
 		const prefix string = ",\"oid\":"
-		out.RawString(prefix)
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
 		if m, ok := in.Oid.(easyjson.Marshaler); ok {
 			m.MarshalEasyJSON(out)
 		} else if m, ok := in.Oid.(json.Marshaler); ok {

--- a/exchange_orders.go
+++ b/exchange_orders.go
@@ -220,6 +220,7 @@ func newModifyOrdersAction(
 		if err != nil {
 			return BatchModifyAction{}, fmt.Errorf("failed to create modify request %d: %w", i, err)
 		}
+		modify.Type = ""
 		modifies[i] = modify
 	}
 


### PR DESCRIPTION
# Pull Request

## Description
Due to adding an extra (undocumentend) parameter to each modifyAction in bulkModify, the packing went wrong. This caused bulk modify to sign the wrong values and it to not work at all.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [x] Generated files are up to date with struct changes

## Screenshots (if applicable)
No "type" for individual modification actions.
<img width="771" height="1029" alt="image" src="https://github.com/user-attachments/assets/d0a27788-3c6a-4863-afac-610e5767141c" />

