### PR TITLE
tighten WsOrder.Status to OrderStatusValue

### DIFF
--- a/types.go
+++ b/types.go
@@ -26,9 +26,12 @@ type Tif string
 
 // Order Time-in-Force constants
 const (
-	TifAlo Tif = "Alo" // Add Liquidity Only
-	TifIoc Tif = "Ioc" // Immediate or Cancel
-	TifGtc Tif = "Gtc" // Good Till Cancel
+	// Add Liquidity Only
+	TifAlo Tif = "Alo"
+	// Immediate or Cancel
+	TifIoc Tif = "Ioc"
+	// Good Till Cancel
+	TifGtc Tif = "Gtc"
 )
 
 type Tpsl string // Advanced order type

--- a/ws_types.go
+++ b/ws_types.go
@@ -109,9 +109,9 @@ type (
 	}
 
 	WsOrder struct {
-		Order           WsBasicOrder `json:"order"`
-		Status          string       `json:"status"`
-		StatusTimestamp int64        `json:"statusTimestamp"`
+		Order           WsBasicOrder     `json:"order"`
+		Status          OrderStatusValue `json:"status"`
+		StatusTimestamp int64            `json:"statusTimestamp"`
 	}
 
 	WsBasicOrder struct {

--- a/ws_types_easyjson.go
+++ b/ws_types_easyjson.go
@@ -568,7 +568,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid4(in *jlexer.Lexer, out
 			if in.IsNull() {
 				in.Skip()
 			} else {
-				out.Status = string(in.String())
+				out.Status = OrderStatusValue(in.String())
 			}
 		case "statusTimestamp":
 			if in.IsNull() {


### PR DESCRIPTION
refactor!: tighten WsOrder.Status to OrderStatusValue; convert TIF comments to doc comments

Strongly type WsOrder.Status as OrderStatusValue and update easyjson decoder. Move inline TIF constant comments above identifiers for proper Go doc comments. BREAKING CHANGE: WsOrder.Status is now OrderStatusValue (was string). Update call sites and comparisons accordingly; JSON wire format is unchanged.

I was banging my head what possible status' could be returned, turns out it was already there just not marked.