### PR TITLE
update types for `BuilderInfo` and `FrontendOpenOrder`

### DIFF
--- a/types.go
+++ b/types.go
@@ -150,8 +150,8 @@ type TriggerOrderType struct {
 }
 
 type BuilderInfo struct {
-	Builder string `json:"b"`
-	Fee     int    `json:"f"`
+	Builder string `json:"b" msgpack:"b"`
+	Fee     int    `json:"f" msgpack:"f"`
 }
 
 type CancelRequest struct {
@@ -249,7 +249,7 @@ type FrontendOpenOrder struct {
 	Sz               float64   `json:"sz,string"`
 	Timestamp        int64     `json:"timestamp"`
 	TriggerCondition string    `json:"triggerCondition"`
-	TriggerPx        string    `json:"triggerPx"`
+	TriggerPx        float64   `json:"triggerPx,string"`
 }
 
 type OrderSide string

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4,6 +4,7 @@ package hyperliquid
 
 import (
 	json "encoding/json"
+
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -5667,7 +5668,7 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid51(in *jlexer.Lexer, ou
 			if in.IsNull() {
 				in.Skip()
 			} else {
-				out.TriggerPx = string(in.String())
+				out.TriggerPx = float64(in.Float64Str())
 			}
 		default:
 			in.SkipRecursive()
@@ -5746,7 +5747,7 @@ func easyjson6601e8cdEncodeGithubComSoniricoGoHyperliquid51(out *jwriter.Writer,
 	{
 		const prefix string = ",\"triggerPx\":"
 		out.RawString(prefix)
-		out.String(string(in.TriggerPx))
+		out.Float64Str(float64(in.TriggerPx))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Pull Request

## Description
- add msgpack to `BuilderInfo`
- change `TriggerPx` data type inside struct `FrontendOpenOrder` from `string` to `float64`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring

## Breaking Changes
This PR might cause error due to changed data type of `TriggerPx`