### PR TITLE
refactor(exchange): enforce typed modify order request identifiers

### DIFF
--- a/examples/order_test.go
+++ b/examples/order_test.go
@@ -100,8 +100,10 @@ func TestModifyOrder(t *testing.T) {
 	t.Log("Modify order method is available and ready to use")
 
 	// Example usage:
+	oid := int64(12345)
+
 	modifyReq := hyperliquid.ModifyOrderRequest{
-		Oid: int64(12345),
+		Oid: &oid,
 		Order: hyperliquid.CreateOrderRequest{
 			Coin:  "BTC",
 			IsBuy: true,
@@ -130,9 +132,10 @@ func TestBulkModifyOrders(t *testing.T) {
 	t.Log("Bulk modify orders method is available and ready to use")
 
 	// Example usage:
+	oid := int64(12345)
 	modifyRequests := []hyperliquid.ModifyOrderRequest{
 		{
-			Oid: int64(12345),
+			Oid: &oid,
 			Order: hyperliquid.CreateOrderRequest{
 				Coin:  "BTC",
 				IsBuy: true,


### PR DESCRIPTION
BREAKING CHANGE: ModifyOrderRequest now requires exactly one of Oid or Cloid pointers.
- replace the untyped identifier with explicit *int64 and *Cloid fields
- validate the chosen identifier and normalize Cloid before wiring the action
- update examples to pass pointer-based order IDs

NB: I locally could not run the tests yet, I was hoping for the Github tests to have an integrated key. If not I'll do it again and record the response.