### PR TITLE
feat: add PerpDeployHaltTrading method

### DIFF
--- a/exchange_others_test.go
+++ b/exchange_others_test.go
@@ -1,0 +1,54 @@
+package hyperliquid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sonirico/vago/ent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerpDeployHaltTrading(t *testing.T) {
+	t.Run("halt trading success response", func(t *testing.T) {
+		loadEnvClean(".env.testnet")
+
+		key := ent.Str("HL_PRIVATE_KEY", "")
+
+		exchange, err := newExchange(key, TestnetAPIURL)
+
+		require.NoError(t, err)
+
+		initRecorder(t, false, "PerpDeployHaltTrading_Success")
+
+		res, err := exchange.PerpDeployHaltTrading(context.TODO(), "test:BTC", true)
+		t.Logf("res: %+v", res)
+		t.Logf("err: %v", err)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		require.Equal(t, "ok", res.Status)
+	})
+
+	t.Run("halt trading error response", func(t *testing.T) {
+		loadEnvClean(".env.testnet")
+
+		key := ent.Str("HL_PRIVATE_KEY", "")
+
+		exchange, err := newExchange(key, TestnetAPIURL)
+
+		require.NoError(t, err)
+
+		initRecorder(t, false, "PerpDeployHaltTrading_Error")
+
+		res, err := exchange.PerpDeployHaltTrading(context.TODO(), "test:BTC", true)
+		t.Logf("res: %+v", res)
+		t.Logf("err: %v", err)
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		require.Equal(t, "err", res.Status)
+		require.NotEmpty(t, res.Response)
+	})
+}

--- a/testdata/PerpDeployHaltTrading_Error.yaml
+++ b/testdata/PerpDeployHaltTrading_Error.yaml
@@ -1,0 +1,52 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 271
+        host: api.hyperliquid-testnet.xyz
+        body: '{"action":{"haltTrading":{"coin":"test:BTC","isHalted":true},"type":"perpDeploy"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.hyperliquid-testnet.xyz/exchange
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 51
+        body: '{"status":"err","response":"Unknown coin test:BTC"}'
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - '*'
+            Connection:
+                - keep-alive
+            Content-Length:
+                - "51"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 18 Dec 2025 09:13:23 GMT
+            Server:
+                - nginx/1.26.2
+            Vary:
+                - origin
+                - access-control-request-method
+                - access-control-request-headers
+            Via:
+                - 1.1 37583b33679eaddf0ec0674860e6da28.cloudfront.net (CloudFront)
+            X-Amz-Cf-Id:
+                - ysnv8xd7ZoVc1zy2sWTHkL6TSyjV9o1QXwrtO5lhXGdfW1IEMWoLDQ==
+            X-Amz-Cf-Pop:
+                - WAW51-P6
+            X-Cache:
+                - Miss from cloudfront
+        status: 200 OK
+        code: 200
+        duration: 626.217421ms

--- a/testdata/PerpDeployHaltTrading_Success.yaml
+++ b/testdata/PerpDeployHaltTrading_Success.yaml
@@ -1,0 +1,52 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 271
+        host: api.hyperliquid-testnet.xyz
+        body: '{"action":{"haltTrading":{"coin":"test:BTC","isHalted":true},"type":"perpDeploy"}}'
+        headers:
+            Content-Type:
+                - application/json
+        url: https://api.hyperliquid-testnet.xyz/exchange
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 51
+        body: '{"status":"ok","data": {"statuses": []}}'
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - '*'
+            Connection:
+                - keep-alive
+            Content-Length:
+                - "51"
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 18 Dec 2025 09:13:20 GMT
+            Server:
+                - nginx/1.26.2
+            Vary:
+                - origin
+                - access-control-request-method
+                - access-control-request-headers
+            Via:
+                - 1.1 37583b33679eaddf0ec0674860e6da28.cloudfront.net (CloudFront)
+            X-Amz-Cf-Id:
+                - Uy-Z2Nr_i6z_PgBnvIrGcLdixsXRBf3cMZA_6fxrmlft0mqOLCFOQg==
+            X-Amz-Cf-Pop:
+                - WAW51-P6
+            X-Cache:
+                - Miss from cloudfront
+        status: 200 OK
+        code: 200
+        duration: 552.43652ms

--- a/types.go
+++ b/types.go
@@ -579,8 +579,9 @@ type MultiSigResponse struct {
 }
 
 type PerpDeployResponse struct {
-	Status string `json:"status"`
-	Data   struct {
+	Status   string `json:"status"`
+	Response string `json:"response,omitempty"`
+	Data     struct {
 		Statuses []TxStatus `json:"statuses"`
 	} `json:"data"`
 }

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4614,6 +4614,12 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid35(in *jlexer.Lexer, ou
 			} else {
 				out.Status = string(in.String())
 			}
+		case "response":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Response = string(in.String())
+			}
 		case "data":
 			easyjson6601e8cdDecode(in, &out.Data)
 		default:
@@ -4634,6 +4640,11 @@ func easyjson6601e8cdEncodeGithubComSoniricoGoHyperliquid35(out *jwriter.Writer,
 		const prefix string = ",\"status\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.Status))
+	}
+	if in.Response != "" {
+		const prefix string = ",\"response\":"
+		out.RawString(prefix)
+		out.String(string(in.Response))
 	}
 	{
 		const prefix string = ",\"data\":"


### PR DESCRIPTION
Not sure if Python SDK provides it but I needed that method today, so decided to add :) 

From docs:

```
{
      type: "perpDeploy",
      haltTrading: { coin: string, isHalted: boolean },
    }
```