### PR TITLE
fix: use DefaultDialer to support proxy for websocket connections

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -135,7 +135,7 @@ func (w *WebsocketClient) Connect(ctx context.Context) error {
 		return nil
 	}
 
-	dialer := websocket.Dialer{}
+	dialer := websocket.DefaultDialer
 
 	//nolint:bodyclose // WebSocket connections don't have response bodies to close
 	conn, _, err := dialer.DialContext(ctx, w.url, nil)


### PR DESCRIPTION
Replace empty websocket.Dialer{} with websocket.DefaultDialer to allow websocket connections to respect system proxy settings (HTTP_PROXY, etc).

# Pull Request

## Description
Use `websocket.DefaultDialer` instead of empty `websocket.Dialer{}` to enable proxy support for WebSocket connections.

This allows WebSocket connections to respect system proxy settings via environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, etc.).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Generated Code
- [ ] I have run `make generate` and committed any generated files
- [ ] Generated files are up to date with struct changes

## Breaking Changes
N/A - This is a non-breaking change. The behavior is identical for users not using proxies.

## Screenshots (if applicable)
N/A

## Additional Notes
The `websocket.DefaultDialer` uses `http.ProxyFromEnvironment` by default, which reads proxy configuration from environment variables. This is useful for users behind corporate proxies or those who need to route WebSocket traffic through a proxy server.
