### PR TITLE
fix: parse collateralToken from meta response

### DIFF
--- a/info.go
+++ b/info.go
@@ -200,9 +200,20 @@ func parseMetaResponse(resp []byte) (*Meta, error) {
 		}
 	}
 
+	// Parse collateralToken (index into SpotMeta.Tokens for this dex's quote currency).
+	// Default perp dex uses 0 (USDC), builder dexes may use different tokens.
+	collateralToken := 0
+	if raw, ok := meta["collateralToken"]; ok {
+		var ct int
+		if err := json.Unmarshal(raw, &ct); err == nil {
+			collateralToken = ct
+		}
+	}
+
 	return &Meta{
-		Universe:     universe,
-		MarginTables: marginTablesResult,
+		Universe:        universe,
+		MarginTables:    marginTablesResult,
+		CollateralToken: collateralToken,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

`parseMetaResponse` was not extracting the `collateralToken` field from the API response, causing `Meta.CollateralToken` to always be `0` (USDC). Builder dexes with non-USDC collateral (e.g. USDH at token index 360) were incorrectly reported as using USDC.

The Hyperliquid API returns `collateralToken` in both the `meta` and `metaAndAssetCtxs` responses. This fix ensures the field is properly parsed and populated in the `Meta` struct.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [x] Generated files are up to date with struct changes