### PR TITLE
fix: encode updateIsolatedMargin ntli as signed micro-USD integer

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -108,10 +108,10 @@ type UpdateLeverageAction struct {
 
 // UpdateIsolatedMarginAction represents isolated margin update
 type UpdateIsolatedMarginAction struct {
-	Type  string  `json:"type"  msgpack:"type"`
-	Asset int     `json:"asset" msgpack:"asset"`
-	IsBuy bool    `json:"isBuy" msgpack:"isBuy"`
-	Ntli  float64 `json:"ntli"  msgpack:"ntli"`
+	Type  string `json:"type"  msgpack:"type"`
+	Asset int    `json:"asset" msgpack:"asset"`
+	IsBuy bool   `json:"isBuy" msgpack:"isBuy"`
+	Ntli  int64  `json:"ntli"  msgpack:"ntli"`
 }
 
 // OrderWire represents the wire format for orders with deterministic field ordering

--- a/actions_easyjson.go
+++ b/actions_easyjson.go
@@ -804,7 +804,7 @@ func easyjsonB97b45a3DecodeGithubComSoniricoGoHyperliquid8(in *jlexer.Lexer, out
 			if in.IsNull() {
 				in.Skip()
 			} else {
-				out.Ntli = float64(in.Float64())
+				out.Ntli = int64(in.Int64())
 			}
 		default:
 			in.SkipRecursive()
@@ -838,7 +838,7 @@ func easyjsonB97b45a3EncodeGithubComSoniricoGoHyperliquid8(out *jwriter.Writer, 
 	{
 		const prefix string = ",\"ntli\":"
 		out.RawString(prefix)
-		out.Float64(float64(in.Ntli))
+		out.Int64(int64(in.Ntli))
 	}
 	out.RawByte('}')
 }

--- a/exchange_others.go
+++ b/exchange_others.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 	"strings"
@@ -49,11 +50,15 @@ func (e *Exchange) UpdateIsolatedMargin(
 		return nil, fmt.Errorf("coin %s not found in info", name)
 	}
 
+	// Match the reference Python SDK: ntli is a signed integer in micro-USD
+	// (float_to_usd_int) and isBuy is always true — the sign of ntli encodes
+	// add vs remove. The previous absolute-value float encoding was rejected
+	// by the exchange (action hash over msgpack float != server-side int).
 	action := UpdateIsolatedMarginAction{
 		Type:  "updateIsolatedMargin",
 		Asset: asset,
-		IsBuy: amount > 0,
-		Ntli:  abs(amount),
+		IsBuy: true,
+		Ntli:  int64(math.Round(amount * 1e6)),
 	}
 
 	var result UserState

--- a/update_isolated_margin_encoding_test.go
+++ b/update_isolated_margin_encoding_test.go
@@ -1,0 +1,27 @@
+package hyperliquid
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The exchange validates the action hash over the msgpack-encoded action, and
+// the reference Python SDK encodes ntli as a signed integer in micro-USD with
+// isBuy always true (hyperliquid-python-sdk signing.float_to_usd_int). This
+// pins the wire shape so a regression back to absolute-value floats fails CI.
+func TestUpdateIsolatedMarginActionWireShape(t *testing.T) {
+	action := UpdateIsolatedMarginAction{
+		Type:  "updateIsolatedMargin",
+		Asset: 7,
+		IsBuy: true,
+		Ntli:  -2_500_000, // remove $2.50
+	}
+	raw, err := json.Marshal(action)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"type":"updateIsolatedMargin","asset":7,"isBuy":true,"ntli":-2500000}`
+	if string(raw) != want {
+		t.Fatalf("wire mismatch:\n got: %s\nwant: %s", raw, want)
+	}
+}


### PR DESCRIPTION
`Exchange.UpdateIsolatedMargin` currently builds the action as:

```go
UpdateIsolatedMarginAction{ ..., IsBuy: amount > 0, Ntli: abs(amount) }
```

with `Ntli float64`. The reference Python SDK ([exchange.py `update_isolated_margin`](https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/hyperliquid/exchange.py) + [`float_to_usd_int`](https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/hyperliquid/utils/signing.py)) encodes `ntli` as a **signed integer in micro-USD** (`round(amount * 1e6)`) with `isBuy` always `true` — the sign of `ntli` carries add vs remove.

So the current encoding is off by 1e6 in magnitude, and the float in the msgpack action hash can never match the server-side integer re-encoding, failing signature validation.

This PR changes `Ntli` to `int64`, encodes `round(amount * 1e6)`, hardcodes `IsBuy: true` (matching Python), updates the easyjson marshaller, and adds a wire-shape regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)