### PR TITLE
feat: adds optional fast flag to l2book ws

### DIFF
--- a/examples/ws_l2book_test.go
+++ b/examples/ws_l2book_test.go
@@ -23,6 +23,7 @@ func TestL2BookWebSocket(t *testing.T) {
 			Coin:     "BTC",
 			Mantissa: 2,
 			NSigFigs: 5,
+			Fast:     true,
 		},
 		func(orderbook hyperliquid.L2Book, err error) {
 			if err != nil {

--- a/ws_sub_l2book.go
+++ b/ws_sub_l2book.go
@@ -6,6 +6,7 @@ type L2BookSubscriptionParams struct {
 	Coin     string
 	NSigFigs int
 	Mantissa int
+	Fast     bool
 }
 
 func (w *WebsocketClient) L2Book(
@@ -17,6 +18,7 @@ func (w *WebsocketClient) L2Book(
 		Coin:     params.Coin,
 		NSigFigs: params.NSigFigs,
 		Mantissa: params.Mantissa,
+		Fast:     params.Fast,
 	}
 
 	return w.subscribe(remotePayload, func(msg any) {

--- a/ws_types_remote.go
+++ b/ws_types_remote.go
@@ -9,6 +9,7 @@ type remoteL2BookSubscriptionPayload struct {
 	Coin     string `json:"coin"`
 	NSigFigs int    `json:"nSigFigs,omitempty"`
 	Mantissa int    `json:"mantissa,omitempty"`
+	Fast     bool   `json:"fast,omitempty"`
 }
 
 func (p remoteL2BookSubscriptionPayload) Channel() string {
@@ -16,7 +17,7 @@ func (p remoteL2BookSubscriptionPayload) Channel() string {
 }
 
 func (p remoteL2BookSubscriptionPayload) Key() string {
-	// Deliberately exclude NSigFigs and Mantissa.
+	// Deliberately exclude NSigFigs, Mantissa and Fast.
 	return keyL2Book(p.Coin)
 }
 

--- a/ws_types_remote_easyjson.go
+++ b/ws_types_remote_easyjson.go
@@ -720,6 +720,12 @@ func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid8(in *jlexer.Lexer, out
 			} else {
 				out.Mantissa = int(in.Int())
 			}
+		case "fast":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Fast = bool(in.Bool())
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -753,6 +759,11 @@ func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid8(out *jwriter.Writer, 
 		const prefix string = ",\"mantissa\":"
 		out.RawString(prefix)
 		out.Int(int(in.Mantissa))
+	}
+	if in.Fast {
+		const prefix string = ",\"fast\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.Fast))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Pull Request

## Description
Adds support for the optional `fast` field on the `l2Book` websocket subscription.

Per the Hyperliquid API announcement (June 9), the next network upgrade changes snapshot-based websocket push frequencies: an `l2Book` subscription with `fast: true` will push **5 levels every 0.5s**, while the default subscription
pushes **20 levels every 5s**. This PR exposes that flag in the SDK so subscribers can opt into the faster feed

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [x] Generated files are up to date with struct changes

## Breaking Changes
None. It's an optional field.

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that would be helpful for reviewers.
