### PR TITLE
feat: adds new fastAssetCtxs ws subscription type

### DIFF
--- a/examples/ws_fast_asset_ctxs_test.go
+++ b/examples/ws_fast_asset_ctxs_test.go
@@ -1,0 +1,45 @@
+package examples
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sonirico/go-hyperliquid"
+)
+
+func TestFastAssetCtxs(t *testing.T) {
+	ws := hyperliquid.NewWebsocketClient("")
+
+	if err := ws.Connect(context.Background()); err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	done := make(chan bool)
+
+	sub, err := ws.FastAssetCtxs(
+		func(ctxs hyperliquid.WsFastAssetCtxs, err error) {
+			if err != nil {
+				t.Errorf("Error in fast asset ctxs callback: %v", err)
+				return
+			}
+
+			t.Logf("Received fast asset ctxs for %d coins", len(ctxs))
+
+			done <- true
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	defer sub.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("Timeout waiting for fast asset ctxs update")
+	}
+}

--- a/ws.go
+++ b/ws.go
@@ -112,6 +112,7 @@ func NewWebsocketClient(baseURL string, opts ...WsOpt) *WebsocketClient {
 			ChannelPong:           NewPongDispatcher(),
 			ChannelTrades:         NewMsgDispatcher[Trades](ChannelTrades),
 			ChannelActiveAssetCtx: NewMsgDispatcher[ActiveAssetCtx](ChannelActiveAssetCtx),
+			ChannelFastAssetCtxs:  NewMsgDispatcher[WsFastAssetCtxs](ChannelFastAssetCtxs),
 			ChannelL2Book:         NewMsgDispatcher[L2Book](ChannelL2Book),
 			ChannelCandle:         NewMsgDispatcher[Candle](ChannelCandle),
 			ChannelAllMids:        NewMsgDispatcher[AllMids](ChannelAllMids),

--- a/ws_sub_fastassetctxs.go
+++ b/ws_sub_fastassetctxs.go
@@ -1,0 +1,54 @@
+package hyperliquid
+
+import (
+	"bytes"
+	"compress/flate"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Data for this type is compressed, decode the base64 then uncompress (RFC 1951, raw — no zlib/gzip wrapper).
+func (w *WsFastAssetCtxs) UnmarshalJSON(data []byte) error {
+	var b64 string
+	if err := json.Unmarshal(data, &b64); err != nil {
+		return fmt.Errorf("fastAssetCtxs: data is not a string: %w", err)
+	}
+
+	compressed, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return fmt.Errorf("fastAssetCtxs: base64 decode: %w", err)
+	}
+
+	raw, err := io.ReadAll(flate.NewReader(bytes.NewReader(compressed)))
+	if err != nil {
+		return fmt.Errorf("fastAssetCtxs: inflate: %w", err)
+	}
+
+	var ctxs map[string]FastAssetCtx
+	if err := json.Unmarshal(raw, &ctxs); err != nil {
+		return fmt.Errorf("fastAssetCtxs: json decode: %w", err)
+	}
+
+	*w = ctxs
+	return nil
+}
+
+func (w *WebsocketClient) FastAssetCtxs(
+	callback func(WsFastAssetCtxs, error),
+) (*Subscription, error) {
+	remotePayload := remoteFastAssetCtxsSubscriptionPayload{
+		Type: ChannelFastAssetCtxs,
+	}
+
+	return w.subscribe(remotePayload, func(msg any) {
+		fastAssetCtx, ok := msg.(WsFastAssetCtxs)
+		if !ok {
+			callback(WsFastAssetCtxs{}, fmt.Errorf("SubscribeToFastAssetCtxs invalid message type"))
+			return
+		}
+
+		callback(fastAssetCtx, nil)
+	})
+}

--- a/ws_types.go
+++ b/ws_types.go
@@ -10,6 +10,7 @@ const (
 	ChannelPong               string = "pong"
 	ChannelTrades             string = "trades"
 	ChannelActiveAssetCtx     string = "activeAssetCtx"
+	ChannelFastAssetCtxs      string = "fastAssetCtxs"
 	ChannelL2Book             string = "l2Book"
 	ChannelCandle             string = "candle"
 	ChannelAllMids            string = "allMids"
@@ -50,6 +51,11 @@ type (
 	ActiveAssetCtx struct {
 		Coin string         `json:"coin"`
 		Ctx  SharedAssetCtx `json:"ctx"`
+	}
+
+	FastAssetCtx struct {
+		MarkPx *float64 `json:"markPx,string,omitempty"`
+		MidPx  *float64 `json:"midPx,string,omitempty"`
 	}
 
 	SharedAssetCtx struct {

--- a/ws_types_easyjson.go
+++ b/ws_types_easyjson.go
@@ -2652,7 +2652,105 @@ func (v *FillLiquidation) UnmarshalJSON(data []byte) error {
 func (v *FillLiquidation) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid20(l, v)
 }
-func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(in *jlexer.Lexer, out *ClearinghouseStateMessage) {
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(in *jlexer.Lexer, out *FastAssetCtx) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		switch key {
+		case "markPx":
+			if in.IsNull() {
+				in.Skip()
+				out.MarkPx = nil
+			} else {
+				if out.MarkPx == nil {
+					out.MarkPx = new(float64)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					*out.MarkPx = float64(in.Float64Str())
+				}
+			}
+		case "midPx":
+			if in.IsNull() {
+				in.Skip()
+				out.MidPx = nil
+			} else {
+				if out.MidPx == nil {
+					out.MidPx = new(float64)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					*out.MidPx = float64(in.Float64Str())
+				}
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(out *jwriter.Writer, in FastAssetCtx) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.MarkPx != nil {
+		const prefix string = ",\"markPx\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Float64Str(float64(*in.MarkPx))
+	}
+	if in.MidPx != nil {
+		const prefix string = ",\"midPx\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Float64Str(float64(*in.MidPx))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v FastAssetCtx) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v FastAssetCtx) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *FastAssetCtx) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *FastAssetCtx) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(l, v)
+}
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(in *jlexer.Lexer, out *ClearinghouseStateMessage) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2694,7 +2792,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(out *jwriter.Writer, in ClearinghouseStateMessage) {
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(out *jwriter.Writer, in ClearinghouseStateMessage) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2730,27 +2828,27 @@ func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v ClearinghouseStateMessage) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(&w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ClearinghouseStateMessage) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid21(w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *ClearinghouseStateMessage) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(&r, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ClearinghouseStateMessage) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid21(l, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(l, v)
 }
-func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(in *jlexer.Lexer, out *ClearinghouseState) {
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(in *jlexer.Lexer, out *ClearinghouseState) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2847,7 +2945,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(out *jwriter.Writer, in ClearinghouseState) {
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(out *jwriter.Writer, in ClearinghouseState) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2922,27 +3020,27 @@ func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v ClearinghouseState) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(&w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ClearinghouseState) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid22(w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *ClearinghouseState) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(&r, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ClearinghouseState) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid22(l, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(l, v)
 }
-func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(in *jlexer.Lexer, out *Candle) {
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(in *jlexer.Lexer, out *Candle) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3026,7 +3124,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(out *jwriter.Writer, in Candle) {
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(out *jwriter.Writer, in Candle) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3086,27 +3184,27 @@ func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v Candle) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(&w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Candle) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid23(w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Candle) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(&r, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Candle) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid23(l, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(l, v)
 }
-func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(in *jlexer.Lexer, out *Bbo) {
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(in *jlexer.Lexer, out *Bbo) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3169,7 +3267,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(out *jwriter.Writer, in Bbo) {
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(out *jwriter.Writer, in Bbo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3205,27 +3303,27 @@ func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v Bbo) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(&w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Bbo) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid24(w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Bbo) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(&r, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Bbo) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid24(l, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(l, v)
 }
-func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(in *jlexer.Lexer, out *AllMids) {
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(in *jlexer.Lexer, out *AllMids) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3269,7 +3367,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(out *jwriter.Writer, in AllMids) {
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(out *jwriter.Writer, in AllMids) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3300,27 +3398,27 @@ func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v AllMids) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(&w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AllMids) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid25(w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AllMids) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(&r, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AllMids) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid25(l, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(l, v)
 }
-func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(in *jlexer.Lexer, out *ActiveAssetCtx) {
+func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid27(in *jlexer.Lexer, out *ActiveAssetCtx) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3356,7 +3454,7 @@ func easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(out *jwriter.Writer, in ActiveAssetCtx) {
+func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid27(out *jwriter.Writer, in ActiveAssetCtx) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3376,23 +3474,23 @@ func easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v ActiveAssetCtx) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(&w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid27(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ActiveAssetCtx) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid26(w, v)
+	easyjson8df87204EncodeGithubComSoniricoGoHyperliquid27(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *ActiveAssetCtx) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(&r, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid27(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ActiveAssetCtx) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid26(l, v)
+	easyjson8df87204DecodeGithubComSoniricoGoHyperliquid27(l, v)
 }

--- a/ws_types_remote.go
+++ b/ws_types_remote.go
@@ -47,6 +47,18 @@ func (p remoteActiveAssetCtxSubscriptionPayload) Key() string {
 	return keyActiveAssetCtx(p.Coin)
 }
 
+type remoteFastAssetCtxsSubscriptionPayload struct {
+	Type string `json:"type"`
+}
+
+func (p remoteFastAssetCtxsSubscriptionPayload) Channel() string {
+	return p.Type
+}
+
+func (p remoteFastAssetCtxsSubscriptionPayload) Key() string {
+	return keyFastAssetCtxs()
+}
+
 type remoteCandlesSubscriptionPayload struct {
 	Type     string `json:"type"`
 	Coin     string `json:"coin"`

--- a/ws_types_remote_easyjson.go
+++ b/ws_types_remote_easyjson.go
@@ -791,7 +791,72 @@ func (v *remoteL2BookSubscriptionPayload) UnmarshalJSON(data []byte) error {
 func (v *remoteL2BookSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid8(l, v)
 }
-func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(in *jlexer.Lexer, out *remoteClearinghouseStateSubscriptionPayload) {
+func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(in *jlexer.Lexer, out *remoteFastAssetCtxsSubscriptionPayload) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		switch key {
+		case "type":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Type = string(in.String())
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(out *jwriter.Writer, in remoteFastAssetCtxsSubscriptionPayload) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"type\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Type))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v remoteFastAssetCtxsSubscriptionPayload) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v remoteFastAssetCtxsSubscriptionPayload) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *remoteFastAssetCtxsSubscriptionPayload) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *remoteFastAssetCtxsSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(l, v)
+}
+func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(in *jlexer.Lexer, out *remoteClearinghouseStateSubscriptionPayload) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -841,7 +906,7 @@ func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(in *jlexer.Lexer, out
 		in.Consumed()
 	}
 }
-func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(out *jwriter.Writer, in remoteClearinghouseStateSubscriptionPayload) {
+func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(out *jwriter.Writer, in remoteClearinghouseStateSubscriptionPayload) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -866,27 +931,27 @@ func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(out *jwriter.Writer, 
 // MarshalJSON supports json.Marshaler interface
 func (v remoteClearinghouseStateSubscriptionPayload) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(&w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v remoteClearinghouseStateSubscriptionPayload) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid9(w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *remoteClearinghouseStateSubscriptionPayload) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(&r, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *remoteClearinghouseStateSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid9(l, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(l, v)
 }
-func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(in *jlexer.Lexer, out *remoteCandlesSubscriptionPayload) {
+func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(in *jlexer.Lexer, out *remoteCandlesSubscriptionPayload) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -928,7 +993,7 @@ func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(out *jwriter.Writer, in remoteCandlesSubscriptionPayload) {
+func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(out *jwriter.Writer, in remoteCandlesSubscriptionPayload) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -953,27 +1018,27 @@ func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v remoteCandlesSubscriptionPayload) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(&w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v remoteCandlesSubscriptionPayload) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid10(w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *remoteCandlesSubscriptionPayload) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(&r, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *remoteCandlesSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid10(l, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(l, v)
 }
-func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(in *jlexer.Lexer, out *remoteBboSubscriptionPayload) {
+func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(in *jlexer.Lexer, out *remoteBboSubscriptionPayload) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1009,7 +1074,7 @@ func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(out *jwriter.Writer, in remoteBboSubscriptionPayload) {
+func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(out *jwriter.Writer, in remoteBboSubscriptionPayload) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1029,27 +1094,27 @@ func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v remoteBboSubscriptionPayload) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(&w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v remoteBboSubscriptionPayload) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid11(w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *remoteBboSubscriptionPayload) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(&r, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *remoteBboSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid11(l, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(l, v)
 }
-func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(in *jlexer.Lexer, out *remoteAllMidsSubscriptionPayload) {
+func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(in *jlexer.Lexer, out *remoteAllMidsSubscriptionPayload) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1093,7 +1158,7 @@ func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(out *jwriter.Writer, in remoteAllMidsSubscriptionPayload) {
+func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(out *jwriter.Writer, in remoteAllMidsSubscriptionPayload) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1113,27 +1178,27 @@ func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v remoteAllMidsSubscriptionPayload) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(&w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v remoteAllMidsSubscriptionPayload) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid12(w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *remoteAllMidsSubscriptionPayload) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(&r, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *remoteAllMidsSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid12(l, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(l, v)
 }
-func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(in *jlexer.Lexer, out *remoteActiveAssetCtxSubscriptionPayload) {
+func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid14(in *jlexer.Lexer, out *remoteActiveAssetCtxSubscriptionPayload) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1169,7 +1234,7 @@ func easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(out *jwriter.Writer, in remoteActiveAssetCtxSubscriptionPayload) {
+func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid14(out *jwriter.Writer, in remoteActiveAssetCtxSubscriptionPayload) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1189,23 +1254,23 @@ func easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(out *jwriter.Writer,
 // MarshalJSON supports json.Marshaler interface
 func (v remoteActiveAssetCtxSubscriptionPayload) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(&w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid14(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v remoteActiveAssetCtxSubscriptionPayload) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid13(w, v)
+	easyjson6658546bEncodeGithubComSoniricoGoHyperliquid14(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *remoteActiveAssetCtxSubscriptionPayload) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(&r, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid14(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *remoteActiveAssetCtxSubscriptionPayload) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid13(l, v)
+	easyjson6658546bDecodeGithubComSoniricoGoHyperliquid14(l, v)
 }

--- a/ws_types_subscriptable.go
+++ b/ws_types_subscriptable.go
@@ -9,6 +9,8 @@ type subscriptable interface {
 type (
 	Trades   []Trade
 	WsOrders []WsOrder
+
+	WsFastAssetCtxs map[string]FastAssetCtx
 )
 
 func (t Trades) Key() string {
@@ -20,6 +22,10 @@ func (t Trades) Key() string {
 
 func (a ActiveAssetCtx) Key() string {
 	return keyActiveAssetCtx(a.Coin)
+}
+
+func (w WsFastAssetCtxs) Key() string {
+	return keyFastAssetCtxs()
 }
 
 func (c Candle) Key() string {

--- a/ws_utils.go
+++ b/ws_utils.go
@@ -18,6 +18,10 @@ func keyActiveAssetCtx(coin string) string {
 	return key(ChannelActiveAssetCtx, coin)
 }
 
+func keyFastAssetCtxs() string {
+	return key(ChannelFastAssetCtxs)
+}
+
 func keyCandles(symbol, interval string) string {
 	return key(ChannelCandle, symbol, interval)
 }


### PR DESCRIPTION
# Pull Request

## Description

Hyperliquid released a new ws subscription type [`fastAssetCtx`](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions#subscription-messages:~:text=Data%20format%3A%20WsOutcomeMetaUpdates-,fastAssetCtxs,-%7B%20%22method%22%3A%20%22subscribe%22%2C%20%22subscription). 

This PR adds that subscription type with a custom UnmarshalJSON inorder to decode and uncompress the data.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `make test` and all checks pass

## Code Quality
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [ ] Generated files are up to date with struct changes
