### PR TITLE
fix: ledgerdelta optional fields

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -360,6 +360,9 @@ func TestLevel_UnmarshalJSON_StringToFloat(t *testing.T) {
 
 func TestLedgerDelta_UnmarshalJSON(t *testing.T) {
 
+	int64Ptr := func(i int64) *int64 { return &i }
+	boolPtr := func(b bool) *bool { return &b }
+
 	tests := []struct {
 		name     string
 		jsonData string
@@ -377,19 +380,33 @@ func TestLedgerDelta_UnmarshalJSON(t *testing.T) {
 				Type:  "withdraw",
 				USDC:  "500.0",
 				Fee:   "1.0",
-				Nonce: 1681923833000,
+				Nonce: int64Ptr(1681923833000),
 			},
 		},
 		{
 			// toPerp:true, not false: with a plain bool a broken json tag would
 			// still yield false and the test would pass regardless
-			name:     "accountClassTransfer",
+			name:     "accountClassTransfer_to_perp",
 			jsonData: `{"type":"accountClassTransfer","usdc":"12.0","toPerp":true}`,
 			expected: LedgerDelta{
 				Type:   "accountClassTransfer",
 				USDC:   "12.0",
-				ToPerp: true,
+				ToPerp: boolPtr(true),
 			},
+		},
+		{
+			name:     "accountClassTransfer_to_spot",
+			jsonData: `{"type":"accountClassTransfer","usdc":"12.0","toPerp":false}`,
+			expected: LedgerDelta{
+				Type:   "accountClassTransfer",
+				USDC:   "12.0",
+				ToPerp: boolPtr(false),
+			},
+		},
+		{
+			name:     "deposit_has_no_toPerp",
+			jsonData: `{"type":"deposit","usdc":"5.0"}`,
+			expected: LedgerDelta{Type: "deposit", USDC: "5.0", ToPerp: nil},
 		},
 		{
 			name:     "spotTransfer_null_nonce",
@@ -403,8 +420,43 @@ func TestLedgerDelta_UnmarshalJSON(t *testing.T) {
 				Destination:    "0xaaa0c2769cb990f4f37db951a9e48de2385c2733",
 				Fee:            "1.0",
 				NativeTokenFee: "0.0",
-				FeeToken:       "USDC",
-				Nonce:          0, // sent as null; 0 is never a real nonce
+				FeeToken:       stringPtr("USDC"),
+				Nonce:          nil,
+			},
+		},
+		{
+			name:     "send_empty_dex_is_a_value",
+			jsonData: `{"type":"send","user":"0xaaa","destination":"0xbbb","sourceDex":"","destinationDex":"spot","token":"USDC","amount":"10.0","usdcValue":"10.0","fee":"0.0","nativeTokenFee":"0.0","nonce":1700000000000,"feeToken":""}`,
+			expected: LedgerDelta{
+				Type:           "send",
+				User:           "0xaaa",
+				Destination:    "0xbbb",
+				SourceDex:      "",
+				DestinationDex: "spot",
+				Token:          "USDC",
+				Amount:         "10.0",
+				UsdcValue:      "10.0",
+				Fee:            "0.0",
+				NativeTokenFee: "0.0",
+				Nonce:          int64Ptr(1700000000000),
+				FeeToken:       stringPtr(""),
+			},
+		},
+		{
+			name:     "deposit_dex_keys_absent",
+			jsonData: `{"type":"deposit","usdc":"1.0"}`,
+			expected: LedgerDelta{
+				Type: "deposit", USDC: "1.0",
+				SourceDex: "", DestinationDex: "", FeeToken: nil,
+			},
+		},
+		{
+			name:     "rewardsClaim_empty_token",
+			jsonData: `{"type":"rewardsClaim","amount":"280.109527","token":""}`,
+			expected: LedgerDelta{
+				Type:   "rewardsClaim",
+				Amount: "280.109527",
+				Token:  "",
 			},
 		},
 		{
@@ -465,7 +517,7 @@ func TestLedgerDelta_UnmarshalJSON(t *testing.T) {
 				Type:      "cStakingTransfer",
 				Token:     "HYPE",
 				Amount:    "5.0",
-				IsDeposit: true,
+				IsDeposit: boolPtr(true),
 			},
 		},
 		{

--- a/types.go
+++ b/types.go
@@ -443,11 +443,11 @@ type LedgerDelta struct {
 	DestinationDex string `json:"destinationDex"`
 
 	// transfers and sends
-	Amount         string `json:"amount,omitempty"`
-	NativeTokenFee string `json:"nativeTokenFee,omitempty"`
-	FeeToken       string `json:"feeToken,omitempty"`
-	Nonce          int64  `json:"nonce,omitempty"`
-	ToPerp         bool   `json:"toPerp,omitempty"`
+	Amount         string  `json:"amount,omitempty"`
+	NativeTokenFee string  `json:"nativeTokenFee,omitempty"`
+	FeeToken       *string `json:"feeToken,omitempty"`
+	Nonce          *int64  `json:"nonce,omitempty"`
+	ToPerp         *bool   `json:"toPerp,omitempty"`
 
 	// vaults
 	Vault           string `json:"vault,omitempty"`
@@ -464,7 +464,7 @@ type LedgerDelta struct {
 	LiquidatedPositions []LiquidatedPosition `json:"liquidatedPositions,omitempty"`
 
 	// staking, borrow/lend and dex abstraction
-	IsDeposit      bool   `json:"isDeposit,omitempty"`
+	IsDeposit      *bool  `json:"isDeposit,omitempty"`
 	Operation      string `json:"operation,omitempty"` // "supply", "withdraw", "repay" or "borrow"
 	InterestAmount string `json:"interestAmount,omitempty"`
 	Dex            string `json:"dex,omitempty"`

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -8531,20 +8531,44 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid70(in *jlexer.Lexer, ou
 		case "feeToken":
 			if in.IsNull() {
 				in.Skip()
+				out.FeeToken = nil
 			} else {
-				out.FeeToken = string(in.String())
+				if out.FeeToken == nil {
+					out.FeeToken = new(string)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					*out.FeeToken = string(in.String())
+				}
 			}
 		case "nonce":
 			if in.IsNull() {
 				in.Skip()
+				out.Nonce = nil
 			} else {
-				out.Nonce = int64(in.Int64())
+				if out.Nonce == nil {
+					out.Nonce = new(int64)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					*out.Nonce = int64(in.Int64())
+				}
 			}
 		case "toPerp":
 			if in.IsNull() {
 				in.Skip()
+				out.ToPerp = nil
 			} else {
-				out.ToPerp = bool(in.Bool())
+				if out.ToPerp == nil {
+					out.ToPerp = new(bool)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					*out.ToPerp = bool(in.Bool())
+				}
 			}
 		case "vault":
 			if in.IsNull() {
@@ -8630,8 +8654,16 @@ func easyjson6601e8cdDecodeGithubComSoniricoGoHyperliquid70(in *jlexer.Lexer, ou
 		case "isDeposit":
 			if in.IsNull() {
 				in.Skip()
+				out.IsDeposit = nil
 			} else {
-				out.IsDeposit = bool(in.Bool())
+				if out.IsDeposit == nil {
+					out.IsDeposit = new(bool)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					*out.IsDeposit = bool(in.Bool())
+				}
 			}
 		case "operation":
 			if in.IsNull() {
@@ -8720,20 +8752,20 @@ func easyjson6601e8cdEncodeGithubComSoniricoGoHyperliquid70(out *jwriter.Writer,
 		out.RawString(prefix)
 		out.String(string(in.NativeTokenFee))
 	}
-	if in.FeeToken != "" {
+	if in.FeeToken != nil {
 		const prefix string = ",\"feeToken\":"
 		out.RawString(prefix)
-		out.String(string(in.FeeToken))
+		out.String(string(*in.FeeToken))
 	}
-	if in.Nonce != 0 {
+	if in.Nonce != nil {
 		const prefix string = ",\"nonce\":"
 		out.RawString(prefix)
-		out.Int64(int64(in.Nonce))
+		out.Int64(int64(*in.Nonce))
 	}
-	if in.ToPerp {
+	if in.ToPerp != nil {
 		const prefix string = ",\"toPerp\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.ToPerp))
+		out.Bool(bool(*in.ToPerp))
 	}
 	if in.Vault != "" {
 		const prefix string = ",\"vault\":"
@@ -8794,10 +8826,10 @@ func easyjson6601e8cdEncodeGithubComSoniricoGoHyperliquid70(out *jwriter.Writer,
 			out.RawByte(']')
 		}
 	}
-	if in.IsDeposit {
+	if in.IsDeposit != nil {
 		const prefix string = ",\"isDeposit\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.IsDeposit))
+		out.Bool(bool(*in.IsDeposit))
 	}
 	if in.Operation != "" {
 		const prefix string = ",\"operation\":"


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #168. Four of the `LedgerDelta` fields added there use plain value types, which makes them unable to represent the values the API actually sends. This changes them to pointers.

`LedgerDelta` models a tagged union where the `type` key selects which other keys are present. For a plain `bool`, an absent key and a present `false` both decode to `false` — and the API uses `false` to carry real meaning. Same for a `null` that should be distinguishable from a zero value.

| field | before | after | why |
|---|---|---|---|
| `ToPerp` | `bool` | `*bool` | `false` means "moved to spot", not "no value" |
| `IsDeposit` | `bool` | `*bool` | `false` means withdrawal, not "no value" |
| `Nonce` | `int64` | `*int64` | API sends explicit `null` on some `spotTransfer` rows |
| `FeeToken` | `string` | `*string` | API sends `""` as a real value |

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `make test` and all checks pass

## Code Quality
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Generated Code
- [x] I have run `make generate` and committed any generated files
- [ ] Generated files are up to date with struct changes

## Breaking Changes

Anyone reading these four fields must update. The fields only became public in #168, so exposure should be small.

```go
// before
if delta.ToPerp { ... }
fmt.Println(delta.Nonce)

// after
if delta.ToPerp != nil && *delta.ToPerp { ... }
if delta.Nonce != nil { fmt.Println(*delta.Nonce) }
```

Since presence is determined by `delta.Type`, the usual shape is to check the discriminator first and dereference inside that branch:

```go
if delta.Type == "accountClassTransfer" && delta.ToPerp != nil {
    if *delta.ToPerp { /* moved to perp */ } else { /* moved to spot */ }
}
```

Since these were only merged in recently, we'd rather merge this in now rather than later such that downstream impact is minimised.

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that would be helpful for reviewers.
